### PR TITLE
Pass filenames for deptry

### DIFF
--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -181,6 +181,7 @@ class DeptryTool(Tool):
                         entry="uv run --frozen deptry src",
                         language=Language("system"),
                         always_run=True,
+                        pass_filenames=False,
                     )
                 ],
             )
@@ -311,7 +312,6 @@ class RuffTool(Tool):
                             [FileType("python"), FileType("pyi"), FileType("jupyter")]
                         ),
                         always_run=True,
-                        pass_filenames=True,
                         require_serial=True,
                     ),
                 ],
@@ -328,7 +328,6 @@ class RuffTool(Tool):
                             [FileType("python"), FileType("pyi"), FileType("jupyter")]
                         ),
                         always_run=True,
-                        pass_filenames=True,
                         require_serial=True,
                     ),
                 ],

--- a/tests/usethis/_core/test_tool.py
+++ b/tests/usethis/_core/test_tool.py
@@ -124,6 +124,7 @@ repos:
         always_run: true
         entry: uv run --frozen deptry src
         language: system
+        pass_filenames: false
 """
             )
 
@@ -191,6 +192,7 @@ repos:
         always_run: true
         entry: uv run --frozen deptry src
         language: system
+        pass_filenames: false
 """
             )
 


### PR DESCRIPTION
Don't explicitly config pass filenames for ruff since the default is True anyway