### PR TITLE
250 add frozen flag

### DIFF
--- a/src/usethis/_config.py
+++ b/src/usethis/_config.py
@@ -1,9 +1,7 @@
-from collections.abc import Generator
-from contextlib import contextmanager
-
 import typer
 from pydantic import BaseModel
-
+from contextlib import contextmanager
+from typing import Generator
 
 class UsethisConfig(BaseModel):
     """Global-state for command options which affect low level behaviour."""
@@ -14,28 +12,33 @@ class UsethisConfig(BaseModel):
 
     @contextmanager
     def set(
-        self, *, offline: bool | None = None, quiet: bool | None = None
+        self, *, offline: bool | None = None, quiet: bool | None = None, frozen: bool | None = None
     ) -> Generator[None, None, None]:
         """Temporarily change command options."""
         old_offline = self.offline
         old_quiet = self.quiet
+        old_frozen = self.frozen
 
         if offline is None:
             offline = old_offline
         if quiet is None:
             quiet = old_quiet
+        if frozen is None:
+            frozen = old_frozen
 
         self.offline = offline
         self.quiet = quiet
+        self.frozen = frozen
         yield
         self.offline = old_offline
         self.quiet = old_quiet
+        self.frozen = old_frozen
 
 
 _OFFLINE_DEFAULT = False
 _QUIET_DEFAULT = False
 
-usethis_config = UsethisConfig(offline=_OFFLINE_DEFAULT, quiet=_QUIET_DEFAULT)
+usethis_config = UsethisConfig(offline=_OFFLINE_DEFAULT, quiet=_QUIET_DEFAULT, frozen=False)
 
 offline_opt = typer.Option(_OFFLINE_DEFAULT, "--offline", help="Disable network access")
 quiet_opt = typer.Option(_QUIET_DEFAULT, "--quiet", help="Suppress output")

--- a/src/usethis/_config.py
+++ b/src/usethis/_config.py
@@ -10,6 +10,7 @@ class UsethisConfig(BaseModel):
 
     offline: bool
     quiet: bool
+    frozen: bool = False 
 
     @contextmanager
     def set(

--- a/src/usethis/_config.py
+++ b/src/usethis/_config.py
@@ -1,18 +1,24 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+
 import typer
 from pydantic import BaseModel
-from contextlib import contextmanager
-from typing import Generator
+
 
 class UsethisConfig(BaseModel):
     """Global-state for command options which affect low level behaviour."""
 
     offline: bool
     quiet: bool
-    frozen: bool = False 
+    frozen: bool = False
 
     @contextmanager
     def set(
-        self, *, offline: bool | None = None, quiet: bool | None = None, frozen: bool | None = None
+        self,
+        *,
+        offline: bool | None = None,
+        quiet: bool | None = None,
+        frozen: bool | None = None,
     ) -> Generator[None, None, None]:
         """Temporarily change command options."""
         old_offline = self.offline
@@ -38,7 +44,9 @@ class UsethisConfig(BaseModel):
 _OFFLINE_DEFAULT = False
 _QUIET_DEFAULT = False
 
-usethis_config = UsethisConfig(offline=_OFFLINE_DEFAULT, quiet=_QUIET_DEFAULT, frozen=False)
+usethis_config = UsethisConfig(
+    offline=_OFFLINE_DEFAULT, quiet=_QUIET_DEFAULT, frozen=False
+)
 
 offline_opt = typer.Option(_OFFLINE_DEFAULT, "--offline", help="Disable network access")
 quiet_opt = typer.Option(_QUIET_DEFAULT, "--quiet", help="Suppress output")

--- a/src/usethis/_console.py
+++ b/src/usethis/_console.py
@@ -1,19 +1,23 @@
+import codecs
 import sys
-sys.stdout.reconfigure(encoding='utf-8')
 
 from rich.console import Console
 
 from usethis._config import usethis_config
+
+# Unicode support - but we need to be able to write bytes
+sys.stdout = codecs.getwriter("utf-8")(sys.stdout.buffer)
 
 console = Console()
 
 
 def tick_print(msg: str | Exception) -> None:
     msg = str(msg)
-    
-    if not usethis_config.quiet:
-        console.print(f"{'✔'.encode('utf-8', 'ignore').decode('utf-8')} {msg}", style="green")
 
+    if not usethis_config.quiet:
+        console.print(
+            f"{'✔'.encode('utf-8', 'ignore').decode('utf-8')} {msg}", style="green"
+        )
 
 
 def box_print(msg: str | Exception) -> None:

--- a/src/usethis/_console.py
+++ b/src/usethis/_console.py
@@ -1,3 +1,6 @@
+import sys
+sys.stdout.reconfigure(encoding='utf-8')
+
 from rich.console import Console
 
 from usethis._config import usethis_config
@@ -7,9 +10,10 @@ console = Console()
 
 def tick_print(msg: str | Exception) -> None:
     msg = str(msg)
-
+    
     if not usethis_config.quiet:
-        console.print(f"✔ {msg}", style="green")
+        console.print(f"{'✔'.encode('utf-8', 'ignore').decode('utf-8')} {msg}", style="green")
+
 
 
 def box_print(msg: str | Exception) -> None:

--- a/src/usethis/_integrations/uv/call.py
+++ b/src/usethis/_integrations/uv/call.py
@@ -1,7 +1,8 @@
+from usethis._config import usethis_config
 from usethis._integrations.pyproject.io_ import read_pyproject_toml_from_path
 from usethis._integrations.uv.errors import UVSubprocessFailedError
 from usethis._subprocess import SubprocessFailedError, call_subprocess
-from usethis._config import usethis_config
+
 
 def call_uv_subprocess(args: list[str]) -> str:
     """Run a subprocess using the uv command-line tool.

--- a/src/usethis/_integrations/uv/call.py
+++ b/src/usethis/_integrations/uv/call.py
@@ -1,7 +1,7 @@
 from usethis._integrations.pyproject.io_ import read_pyproject_toml_from_path
 from usethis._integrations.uv.errors import UVSubprocessFailedError
 from usethis._subprocess import SubprocessFailedError, call_subprocess
-
+from usethis._config import usethis_config
 
 def call_uv_subprocess(args: list[str]) -> str:
     """Run a subprocess using the uv command-line tool.
@@ -11,6 +11,9 @@ def call_uv_subprocess(args: list[str]) -> str:
     """
     read_pyproject_toml_from_path.cache_clear()
     try:
+        if usethis_config.frozen:
+            args.append("--frozen")
+            return call_subprocess(["uv", *args], check=False)
         return call_subprocess(["uv", *args])
     except SubprocessFailedError as err:
         raise UVSubprocessFailedError(err) from None

--- a/src/usethis/_integrations/uv/call.py
+++ b/src/usethis/_integrations/uv/call.py
@@ -10,10 +10,10 @@ def call_uv_subprocess(args: list[str]) -> str:
         UVSubprocessFailedError: If the subprocess fails.
     """
     read_pyproject_toml_from_path.cache_clear()
+    new_args = ["uv", *args]
+    if usethis_config.frozen:
+        new_args.append("--frozen")
     try:
-        if usethis_config.frozen:
-            args.append("--frozen")
-            return call_subprocess(["uv", *args], check=False)
-        return call_subprocess(["uv", *args])
+        return call_subprocess(new_args)
     except SubprocessFailedError as err:
         raise UVSubprocessFailedError(err) from None

--- a/src/usethis/_interface/tool.py
+++ b/src/usethis/_interface/tool.py
@@ -22,13 +22,15 @@ remove_opt = typer.Option(
     False, "--remove", help="Remove the tool instead of adding it."
 )
 
-frozen_opt = typer.Option(
-    False,"--frozen", help="Use the frozen dependencies."
-)
+frozen_opt = typer.Option(False, "--frozen", help="Use the frozen dependencies.")
+
 
 @app.command(help="Use the coverage code coverage measurement tool.")
 def coverage(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
+    remove: bool = remove_opt,
+    offline: bool = offline_opt,
+    quiet: bool = quiet_opt,
+    frozen: bool = frozen_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_coverage, remove=remove)
@@ -38,7 +40,10 @@ def coverage(
     help="Use the deptry linter: avoid missing or superfluous dependency declarations."
 )
 def deptry(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
+    remove: bool = remove_opt,
+    offline: bool = offline_opt,
+    quiet: bool = quiet_opt,
+    frozen: bool = frozen_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_deptry, remove=remove)
@@ -48,7 +53,10 @@ def deptry(
     help="Use the pre-commit framework to manage and maintain pre-commit hooks."
 )
 def pre_commit(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
+    remove: bool = remove_opt,
+    offline: bool = offline_opt,
+    quiet: bool = quiet_opt,
+    frozen: bool = frozen_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_pre_commit, remove=remove)
@@ -58,7 +66,10 @@ def pre_commit(
     help="Use the pyproject-fmt linter: opinionated formatting of 'pyproject.toml' files."
 )
 def pyproject_fmt(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
+    remove: bool = remove_opt,
+    offline: bool = offline_opt,
+    quiet: bool = quiet_opt,
+    frozen: bool = frozen_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_pyproject_fmt, remove=remove)
@@ -66,7 +77,10 @@ def pyproject_fmt(
 
 @app.command(help="Use the pytest testing framework.")
 def pytest(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
+    remove: bool = remove_opt,
+    offline: bool = offline_opt,
+    quiet: bool = quiet_opt,
+    frozen: bool = frozen_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_pytest, remove=remove)
@@ -77,7 +91,10 @@ def pytest(
     help="Use a requirements.txt file exported from the uv lockfile.",
 )
 def requirements_txt(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
+    remove: bool = remove_opt,
+    offline: bool = offline_opt,
+    quiet: bool = quiet_opt,
+    frozen: bool = frozen_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_requirements_txt, remove=remove)
@@ -85,7 +102,10 @@ def requirements_txt(
 
 @app.command(help="Use Ruff: an extremely fast Python linter and code formatter.")
 def ruff(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
+    remove: bool = remove_opt,
+    offline: bool = offline_opt,
+    quiet: bool = quiet_opt,
+    frozen: bool = frozen_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_ruff, remove=remove)

--- a/src/usethis/_interface/tool.py
+++ b/src/usethis/_interface/tool.py
@@ -26,12 +26,11 @@ frozen_opt = typer.Option(
     False,"--frozen", help="Use the frozen dependencies."
 )
 
-
 @app.command(help="Use the coverage code coverage measurement tool.")
 def coverage(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt
+    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
 ) -> None:
-    with usethis_config.set(offline=offline, quiet=quiet):
+    with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_coverage, remove=remove)
 
 
@@ -39,9 +38,9 @@ def coverage(
     help="Use the deptry linter: avoid missing or superfluous dependency declarations."
 )
 def deptry(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt
+    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
 ) -> None:
-    with usethis_config.set(offline=offline, quiet=quiet):
+    with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_deptry, remove=remove)
 
 
@@ -49,9 +48,9 @@ def deptry(
     help="Use the pre-commit framework to manage and maintain pre-commit hooks."
 )
 def pre_commit(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt
+    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
 ) -> None:
-    with usethis_config.set(offline=offline, quiet=quiet):
+    with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_pre_commit, remove=remove)
 
 
@@ -59,17 +58,17 @@ def pre_commit(
     help="Use the pyproject-fmt linter: opinionated formatting of 'pyproject.toml' files."
 )
 def pyproject_fmt(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt
+    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
 ) -> None:
-    with usethis_config.set(offline=offline, quiet=quiet):
+    with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_pyproject_fmt, remove=remove)
 
 
 @app.command(help="Use the pytest testing framework.")
 def pytest(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt
+    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
 ) -> None:
-    with usethis_config.set(offline=offline, quiet=quiet):
+    with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_pytest, remove=remove)
 
 
@@ -78,17 +77,17 @@ def pytest(
     help="Use a requirements.txt file exported from the uv lockfile.",
 )
 def requirements_txt(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt
+    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
 ) -> None:
-    with usethis_config.set(offline=offline, quiet=quiet):
+    with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_requirements_txt, remove=remove)
 
 
 @app.command(help="Use Ruff: an extremely fast Python linter and code formatter.")
 def ruff(
-    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt
+    remove: bool = remove_opt, offline: bool = offline_opt, quiet: bool = quiet_opt, frozen: bool = frozen_opt
 ) -> None:
-    with usethis_config.set(offline=offline, quiet=quiet):
+    with usethis_config.set(offline=offline, quiet=quiet, frozen=frozen):
         _run_tool(use_ruff, remove=remove)
 
 

--- a/src/usethis/_interface/tool.py
+++ b/src/usethis/_interface/tool.py
@@ -22,6 +22,10 @@ remove_opt = typer.Option(
     False, "--remove", help="Remove the tool instead of adding it."
 )
 
+frozen_opt = typer.Option(
+    False,"--frozen", help="Use the frozen dependencies."
+)
+
 
 @app.command(help="Use the coverage code coverage measurement tool.")
 def coverage(

--- a/tests/usethis/_interface/test_tool.py
+++ b/tests/usethis/_interface/test_tool.py
@@ -18,6 +18,18 @@ class TestDeptry:
             else:
                 call_subprocess(["usethis", "tool", "deptry", "--offline"])
 
+    @pytest.mark.usefixtures("_vary_network_conn")
+    def test_cli_frozen(self, uv_init_dir: Path):
+        with change_cwd(uv_init_dir):
+            call_subprocess(["usethis", "tool", "deptry", "--frozen"])
+            assert not (uv_init_dir / ".venv").exists()
+
+    @pytest.mark.usefixtures("_vary_network_conn")
+    def test_cli_not_frozen(self, uv_init_dir: Path):
+        with change_cwd(uv_init_dir):
+            call_subprocess(["usethis", "tool", "deptry"])
+            assert (uv_init_dir / ".venv").exists()
+
 
 class TestPreCommit:
     @pytest.mark.usefixtures("_vary_network_conn")


### PR DESCRIPTION
• Added support for a new --frozen flag for CLI commands. 
The frozen attribute is now part of the global configuration (UsethisConfig) with a corresponding context manager update. The uv subprocess call now appends the "--frozen" flag when enabled.

• Updated _console.py to improve support on Windows, ensuring proper handling of error output and console functionality.

These changes resolve failing test cases related to the --frozen flag and address platform-specific console issues on Windows.