### PR TITLE
#247 Refactor bitbucket

### DIFF
--- a/src/usethis/_ci.py
+++ b/src/usethis/_ci.py
@@ -15,59 +15,6 @@ def is_bitbucket_used() -> bool:
     return (Path.cwd() / "bitbucket-pipelines.yml").exists()
 
 
-def get_bitbucket_pre_commit_step() -> Step:
-    return Step(
-        name="Run pre-commit",
-        caches=["uv", "pre-commit"],
-        script=Script(
-            [
-                ScriptItemAnchor(name="install-uv"),
-                "uv run pre-commit run --all-files",
-            ]
-        ),
-    )
-
-
-def get_bitbucket_ruff_step() -> Step:
-    return Step(
-        name="Run Ruff",
-        caches=["uv"],
-        script=Script(
-            [
-                ScriptItemAnchor(name="install-uv"),
-                "uv run ruff check --fix",
-                "uv run ruff format",
-            ]
-        ),
-    )
-
-
-def get_bitbucket_deptry_step() -> Step:
-    return Step(
-        name="Run Deptry",
-        caches=["uv"],
-        script=Script(
-            [
-                ScriptItemAnchor(name="install-uv"),
-                "uv run deptry src",
-            ]
-        ),
-    )
-
-
-def get_bitbucket_pyproject_fmt_step() -> Step:
-    return Step(
-        name="Run pyproject-fmt",
-        caches=["uv"],
-        script=Script(
-            [
-                ScriptItemAnchor(name="install-uv"),
-                "uv run pyproject-fmt pyproject.toml",
-            ]
-        ),
-    )
-
-
 def update_bitbucket_pytest_steps() -> None:
     matrix = get_supported_major_python_versions()
     for version in matrix:

--- a/src/usethis/_core/ci.py
+++ b/src/usethis/_core/ci.py
@@ -4,7 +4,9 @@ from usethis._integrations.bitbucket.config import (
     add_bitbucket_pipeline_config,
     remove_bitbucket_pipeline_config,
 )
-from usethis._integrations.bitbucket.steps import add_bitbucket_step_in_default
+from usethis._integrations.bitbucket.steps import (
+    add_bitbucket_steps_in_default,
+)
 from usethis._integrations.uv.init import ensure_pyproject_toml
 from usethis._tool import (
     DeptryTool,
@@ -31,16 +33,16 @@ def use_ci_bitbucket(*, remove: bool = False) -> None:
         add_bitbucket_pipeline_config(report_placeholder=not use_any_tool)
 
         if use_pre_commit:
-            add_bitbucket_step_in_default(PreCommitTool().get_bitbucket_step())
+            add_bitbucket_steps_in_default(PreCommitTool().get_bitbucket_steps())
         else:
             # This order should match the canonical order in the function which add
             # steps
             if use_pyproject_fmt:
-                add_bitbucket_step_in_default(PyprojectFmtTool().get_bitbucket_step())
+                add_bitbucket_steps_in_default(PyprojectFmtTool().get_bitbucket_steps())
             if use_ruff:
-                add_bitbucket_step_in_default(RuffTool().get_bitbucket_step())
+                add_bitbucket_steps_in_default(RuffTool().get_bitbucket_steps())
             if use_deptry:
-                add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
+                add_bitbucket_steps_in_default(DeptryTool().get_bitbucket_steps())
 
         if use_pytest:
             update_bitbucket_pytest_steps()

--- a/src/usethis/_core/ci.py
+++ b/src/usethis/_core/ci.py
@@ -31,20 +31,16 @@ def use_ci_bitbucket(*, remove: bool = False) -> None:
         add_bitbucket_pipeline_config(report_placeholder=not use_any_tool)
 
         if use_pre_commit:
-            pre_commit_tool = PreCommitTool()
-            add_bitbucket_step_in_default(pre_commit_tool.get_bitbucket_step())
+            add_bitbucket_step_in_default(PreCommitTool().get_bitbucket_step())
         else:
             # This order should match the canonical order in the function which add
             # steps
             if use_pyproject_fmt:
-                pyproject_fmt_tool = PyprojectFmtTool()
-                add_bitbucket_step_in_default(pyproject_fmt_tool.get_bitbucket_step())
+                add_bitbucket_step_in_default(PyprojectFmtTool().get_bitbucket_step())
             if use_ruff:
-                ruff_tool = RuffTool()
-                add_bitbucket_step_in_default(ruff_tool.get_bitbucket_step())
+                add_bitbucket_step_in_default(RuffTool().get_bitbucket_step())
             if use_deptry:
-                deptry_tool = DeptryTool()
-                add_bitbucket_step_in_default(deptry_tool.get_bitbucket_step())
+                add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
 
         if use_pytest:
             update_bitbucket_pytest_steps()

--- a/src/usethis/_core/ci.py
+++ b/src/usethis/_core/ci.py
@@ -15,45 +15,50 @@ from usethis._tool import (
 )
 
 
+def _add_optional_bitbucket_steps(
+    use_pyproject_fmt: bool, use_ruff: bool, use_deptry: bool
+) -> None:
+    if use_pyproject_fmt:
+        step = PyprojectFmtTool().get_bitbucket_step()
+        if step:
+            add_bitbucket_step_in_default(step)
+    if use_ruff:
+        step = RuffTool().get_bitbucket_step()
+        if step:
+            add_bitbucket_step_in_default(step)
+    if use_deptry:
+        step = DeptryTool().get_bitbucket_step()
+        if step:
+            add_bitbucket_step_in_default(step)
+
+
 def use_ci_bitbucket(*, remove: bool = False) -> None:
     ensure_pyproject_toml()
-
-    if not remove:
-        use_pre_commit = PreCommitTool().is_used()
-        use_pytest = PytestTool().is_used()
-        use_ruff = RuffTool().is_used()
-        use_deptry = DeptryTool().is_used()
-        use_pyproject_fmt = PyprojectFmtTool().is_used()
-        use_any_tool = (
-            use_pre_commit or use_pytest or use_ruff or use_deptry or use_pyproject_fmt
-        )
-
-        add_bitbucket_pipeline_config(report_placeholder=not use_any_tool)
-
-        if use_pre_commit:
-            pre_commit_tool = PreCommitTool()
-            add_bitbucket_step_in_default(pre_commit_tool.get_bitbucket_step())
-        else:
-            # This order should match the canonical order in the function which add
-            # steps
-            if use_pyproject_fmt:
-                pyproject_fmt_tool = PyprojectFmtTool()
-                add_bitbucket_step_in_default(pyproject_fmt_tool.get_bitbucket_step())
-            if use_ruff:
-                ruff_tool = RuffTool()
-                add_bitbucket_step_in_default(ruff_tool.get_bitbucket_step())
-            if use_deptry:
-                deptry_tool = DeptryTool()
-                add_bitbucket_step_in_default(deptry_tool.get_bitbucket_step())
-
-        if use_pytest:
-            update_bitbucket_pytest_steps()
-
-        else:
-            info_print(
-                "Consider `usethis tool pytest` to test your code for the pipeline."
-            )
-
-        box_print("Run your pipeline via the Bitbucket website.")
-    else:
+    if remove:
         remove_bitbucket_pipeline_config()
+        return  # Early return to reduce branch depth
+
+    use_pre_commit = PreCommitTool().is_used()
+    use_pytest = PytestTool().is_used()
+    use_ruff = RuffTool().is_used()
+    use_deptry = DeptryTool().is_used()
+    use_pyproject_fmt = PyprojectFmtTool().is_used()
+    use_any_tool = (
+        use_pre_commit or use_pytest or use_ruff or use_deptry or use_pyproject_fmt
+    )
+
+    add_bitbucket_pipeline_config(report_placeholder=not use_any_tool)
+
+    if use_pre_commit:
+        step = PreCommitTool().get_bitbucket_step()
+        if step:
+            add_bitbucket_step_in_default(step)
+    else:
+        _add_optional_bitbucket_steps(use_pyproject_fmt, use_ruff, use_deptry)
+
+    if use_pytest:
+        update_bitbucket_pytest_steps()
+    else:
+        info_print("Consider `usethis tool pytest` to test your code for the pipeline.")
+
+    box_print("Run your pipeline via the Bitbucket website.")

--- a/src/usethis/_core/ci.py
+++ b/src/usethis/_core/ci.py
@@ -1,10 +1,4 @@
-from usethis._ci import (
-    get_bitbucket_deptry_step,
-    get_bitbucket_pre_commit_step,
-    get_bitbucket_pyproject_fmt_step,
-    get_bitbucket_ruff_step,
-    update_bitbucket_pytest_steps,
-)
+from usethis._ci import update_bitbucket_pytest_steps
 from usethis._console import box_print, info_print
 from usethis._integrations.bitbucket.config import (
     add_bitbucket_pipeline_config,
@@ -37,16 +31,20 @@ def use_ci_bitbucket(*, remove: bool = False) -> None:
         add_bitbucket_pipeline_config(report_placeholder=not use_any_tool)
 
         if use_pre_commit:
-            add_bitbucket_step_in_default(get_bitbucket_pre_commit_step())
+            pre_commit_tool = PreCommitTool()
+            add_bitbucket_step_in_default(pre_commit_tool.get_bitbucket_step())
         else:
             # This order should match the canonical order in the function which add
             # steps
             if use_pyproject_fmt:
-                add_bitbucket_step_in_default(get_bitbucket_pyproject_fmt_step())
+                pyproject_fmt_tool = PyprojectFmtTool()
+                add_bitbucket_step_in_default(pyproject_fmt_tool.get_bitbucket_step())
             if use_ruff:
-                add_bitbucket_step_in_default(get_bitbucket_ruff_step())
+                ruff_tool = RuffTool()
+                add_bitbucket_step_in_default(ruff_tool.get_bitbucket_step())
             if use_deptry:
-                add_bitbucket_step_in_default(get_bitbucket_deptry_step())
+                deptry_tool = DeptryTool()
+                add_bitbucket_step_in_default(deptry_tool.get_bitbucket_step())
 
         if use_pytest:
             update_bitbucket_pytest_steps()

--- a/src/usethis/_core/tool.py
+++ b/src/usethis/_core/tool.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 
 from usethis._ci import (
+    get_bitbucket_deptry_step,
+    get_bitbucket_pre_commit_step,
+    get_bitbucket_pyproject_fmt_step,
+    get_bitbucket_ruff_step,
     is_bitbucket_used,
+    remove_bitbucket_pytest_steps,
+    update_bitbucket_pytest_steps,
 )
 from usethis._console import box_print, tick_print
 from usethis._integrations.bitbucket.steps import (
@@ -79,13 +85,13 @@ def use_deptry(*, remove: bool = False) -> None:
         if PreCommitTool().is_used():
             tool.add_pre_commit_repo_configs()
         elif is_bitbucket_used():
-            add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
+            add_bitbucket_step_in_default(get_bitbucket_deptry_step())
 
         box_print("Run 'deptry src' to run deptry.")
     else:
         tool.remove_pre_commit_repo_configs()
         tool.remove_pyproject_configs()
-        remove_bitbucket_step_from_default(DeptryTool().get_bitbucket_step())
+        remove_bitbucket_step_from_default(get_bitbucket_deptry_step())
         remove_deps_from_group(tool.dev_deps, "dev")
 
 
@@ -100,6 +106,7 @@ def use_pre_commit(*, remove: bool = False) -> None:
         _add_all_tools_pre_commit_configs()
 
         if pyproject_fmt_tool.is_used():
+            # We will use pre-commit instead of the dev-dep.
             remove_deps_from_group(pyproject_fmt_tool.dev_deps, "dev")
             pyproject_fmt_tool.add_pyproject_configs()
             _pyproject_fmt_instructions_pre_commit()
@@ -113,15 +120,16 @@ def use_pre_commit(*, remove: bool = False) -> None:
         install_pre_commit_hooks()
 
         if is_bitbucket_used():
-            add_bitbucket_step_in_default(PreCommitTool().get_bitbucket_step())
+            add_bitbucket_step_in_default(get_bitbucket_pre_commit_step())
             _remove_bitbucket_linter_steps_from_default()
 
         box_print("Run 'pre-commit run --all-files' to run the hooks manually.")
     else:
         if is_bitbucket_used():
-            remove_bitbucket_step_from_default(PreCommitTool().get_bitbucket_step())
+            remove_bitbucket_step_from_default(get_bitbucket_pre_commit_step())
             _add_bitbucket_linter_steps_to_default()
 
+        # Need pre-commit to be installed so we can uninstall hooks
         add_deps_to_group(tool.dev_deps, "dev")
 
         uninstall_pre_commit_hooks()
@@ -129,10 +137,14 @@ def use_pre_commit(*, remove: bool = False) -> None:
         remove_pre_commit_config()
         remove_deps_from_group(tool.dev_deps, "dev")
 
+        # Need to add a new way of running some hooks manually if they are not dev
+        # dependencies yet - explain to the user.
         if pyproject_fmt_tool.is_used():
             add_deps_to_group(pyproject_fmt_tool.dev_deps, "dev")
             _pyproject_fmt_instructions_basic()
 
+        # Likewise, explain how to manually generate the requirements.txt file, since
+        # they're not going to do it via pre-commit anymore.
         if RequirementsTxtTool().is_used():
             _requirements_txt_instructions_basic()
 
@@ -144,16 +156,20 @@ def _add_all_tools_pre_commit_configs():
 
 
 def _add_bitbucket_linter_steps_to_default() -> None:
+    # This order of adding tools should be synced with the order hard-coded
+    # in the function which adds steps.
     if is_bitbucket_used():
         if PyprojectFmtTool().is_used():
-            add_bitbucket_step_in_default(PyprojectFmtTool().get_bitbucket_step())
+            add_bitbucket_step_in_default(get_bitbucket_pyproject_fmt_step())
         if DeptryTool().is_used():
-            add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
+            add_bitbucket_step_in_default(get_bitbucket_deptry_step())
         if RuffTool().is_used():
-            add_bitbucket_step_in_default(RuffTool().get_bitbucket_step())
+            add_bitbucket_step_in_default(get_bitbucket_ruff_step())
 
 
 def _remove_bitbucket_linter_steps_from_default() -> None:
+    # This order of removing tools should be synced with the order hard-coded
+    # in the function which adds steps.
     remove_bitbucket_step_from_default(PyprojectFmtTool().get_bitbucket_step())
     remove_bitbucket_step_from_default(DeptryTool().get_bitbucket_step())
     remove_bitbucket_step_from_default(RuffTool().get_bitbucket_step())
@@ -210,10 +226,12 @@ def use_pytest(*, remove: bool = False) -> None:
         if RuffTool().is_used():
             select_ruff_rules(tool.get_associated_ruff_rules())
 
+        # deptry currently can't scan the tests folder for dev deps
+        # https://github.com/fpgmaas/deptry/issues/302
         add_pytest_dir()
 
         if is_bitbucket_used():
-            pass
+            update_bitbucket_pytest_steps()
 
         box_print(
             "Add test files to the '/tests' directory with the format 'test_*.py'."
@@ -225,14 +243,14 @@ def use_pytest(*, remove: bool = False) -> None:
             _coverage_instructions_pytest()
     else:
         if is_bitbucket_used():
-            pass
+            remove_bitbucket_pytest_steps()
 
         if RuffTool().is_used():
             deselect_ruff_rules(tool.get_associated_ruff_rules())
         tool.remove_pyproject_configs()
         remove_deps_from_group([*tool.dev_deps, Dependency(name="pytest-cov")], "test")
 
-        remove_pytest_dir()
+        remove_pytest_dir()  # Last, since this is a manual step
 
         if CoverageTool().is_used():
             _coverage_instructions_basic()
@@ -252,6 +270,7 @@ def use_requirements_txt(*, remove: bool = False) -> None:
             tool.add_pre_commit_repo_configs()
 
         if not path.exists():
+            # N.B. this is where a task runner would come in handy, to reduce duplication.
             if not (Path.cwd() / "uv.lock").exists():
                 tick_print("Writing 'uv.lock'.")
                 call_uv_subprocess(["lock"])

--- a/src/usethis/_core/tool.py
+++ b/src/usethis/_core/tool.py
@@ -1,13 +1,7 @@
 from pathlib import Path
 
 from usethis._ci import (
-    get_bitbucket_deptry_step,
-    get_bitbucket_pre_commit_step,
-    get_bitbucket_pyproject_fmt_step,
-    get_bitbucket_ruff_step,
     is_bitbucket_used,
-    remove_bitbucket_pytest_steps,
-    update_bitbucket_pytest_steps,
 )
 from usethis._console import box_print, tick_print
 from usethis._integrations.bitbucket.steps import (
@@ -85,13 +79,13 @@ def use_deptry(*, remove: bool = False) -> None:
         if PreCommitTool().is_used():
             tool.add_pre_commit_repo_configs()
         elif is_bitbucket_used():
-            add_bitbucket_step_in_default(get_bitbucket_deptry_step())
+            add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
 
         box_print("Run 'deptry src' to run deptry.")
     else:
         tool.remove_pre_commit_repo_configs()
         tool.remove_pyproject_configs()
-        remove_bitbucket_step_from_default(get_bitbucket_deptry_step())
+        remove_bitbucket_step_from_default(DeptryTool().get_bitbucket_step())
         remove_deps_from_group(tool.dev_deps, "dev")
 
 
@@ -106,7 +100,6 @@ def use_pre_commit(*, remove: bool = False) -> None:
         _add_all_tools_pre_commit_configs()
 
         if pyproject_fmt_tool.is_used():
-            # We will use pre-commit instead of the dev-dep.
             remove_deps_from_group(pyproject_fmt_tool.dev_deps, "dev")
             pyproject_fmt_tool.add_pyproject_configs()
             _pyproject_fmt_instructions_pre_commit()
@@ -120,16 +113,15 @@ def use_pre_commit(*, remove: bool = False) -> None:
         install_pre_commit_hooks()
 
         if is_bitbucket_used():
-            add_bitbucket_step_in_default(get_bitbucket_pre_commit_step())
+            add_bitbucket_step_in_default(PreCommitTool().get_bitbucket_step())
             _remove_bitbucket_linter_steps_from_default()
 
         box_print("Run 'pre-commit run --all-files' to run the hooks manually.")
     else:
         if is_bitbucket_used():
-            remove_bitbucket_step_from_default(get_bitbucket_pre_commit_step())
+            remove_bitbucket_step_from_default(PreCommitTool().get_bitbucket_step())
             _add_bitbucket_linter_steps_to_default()
 
-        # Need pre-commit to be installed so we can uninstall hooks
         add_deps_to_group(tool.dev_deps, "dev")
 
         uninstall_pre_commit_hooks()
@@ -137,14 +129,10 @@ def use_pre_commit(*, remove: bool = False) -> None:
         remove_pre_commit_config()
         remove_deps_from_group(tool.dev_deps, "dev")
 
-        # Need to add a new way of running some hooks manually if they are not dev
-        # dependencies yet - explain to the user.
         if pyproject_fmt_tool.is_used():
             add_deps_to_group(pyproject_fmt_tool.dev_deps, "dev")
             _pyproject_fmt_instructions_basic()
 
-        # Likewise, explain how to manually generate the requirements.txt file, since
-        # they're not going to do it via pre-commit anymore.
         if RequirementsTxtTool().is_used():
             _requirements_txt_instructions_basic()
 
@@ -156,23 +144,19 @@ def _add_all_tools_pre_commit_configs():
 
 
 def _add_bitbucket_linter_steps_to_default() -> None:
-    # This order of adding tools should be synced with the order hard-coded
-    # in the function which adds steps.
     if is_bitbucket_used():
         if PyprojectFmtTool().is_used():
-            add_bitbucket_step_in_default(get_bitbucket_pyproject_fmt_step())
+            add_bitbucket_step_in_default(PyprojectFmtTool().get_bitbucket_step())
         if DeptryTool().is_used():
-            add_bitbucket_step_in_default(get_bitbucket_deptry_step())
+            add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
         if RuffTool().is_used():
-            add_bitbucket_step_in_default(get_bitbucket_ruff_step())
+            add_bitbucket_step_in_default(RuffTool().get_bitbucket_step())
 
 
 def _remove_bitbucket_linter_steps_from_default() -> None:
-    # This order of removing tools should be synced with the order hard-coded
-    # in the function which adds steps.
-    remove_bitbucket_step_from_default(get_bitbucket_pyproject_fmt_step())
-    remove_bitbucket_step_from_default(get_bitbucket_deptry_step())
-    remove_bitbucket_step_from_default(get_bitbucket_ruff_step())
+    remove_bitbucket_step_from_default(PyprojectFmtTool().get_bitbucket_step())
+    remove_bitbucket_step_from_default(DeptryTool().get_bitbucket_step())
+    remove_bitbucket_step_from_default(RuffTool().get_bitbucket_step())
 
 
 def use_pyproject_fmt(*, remove: bool = False) -> None:
@@ -186,7 +170,7 @@ def use_pyproject_fmt(*, remove: bool = False) -> None:
         if not is_pre_commit:
             add_deps_to_group(tool.dev_deps, "dev")
             if is_bitbucket_used():
-                add_bitbucket_step_in_default(get_bitbucket_pyproject_fmt_step())
+                add_bitbucket_step_in_default(tool.get_bitbucket_step())
         else:
             tool.add_pre_commit_repo_configs()
 
@@ -197,7 +181,7 @@ def use_pyproject_fmt(*, remove: bool = False) -> None:
         else:
             _pyproject_fmt_instructions_pre_commit()
     else:
-        remove_bitbucket_step_from_default(get_bitbucket_pyproject_fmt_step())
+        remove_bitbucket_step_from_default(tool.get_bitbucket_step())
         tool.remove_pyproject_configs()
         tool.remove_pre_commit_repo_configs()
         remove_deps_from_group(tool.dev_deps, "dev")
@@ -226,12 +210,10 @@ def use_pytest(*, remove: bool = False) -> None:
         if RuffTool().is_used():
             select_ruff_rules(tool.get_associated_ruff_rules())
 
-        # deptry currently can't scan the tests folder for dev deps
-        # https://github.com/fpgmaas/deptry/issues/302
         add_pytest_dir()
 
         if is_bitbucket_used():
-            update_bitbucket_pytest_steps()
+            pass
 
         box_print(
             "Add test files to the '/tests' directory with the format 'test_*.py'."
@@ -243,14 +225,14 @@ def use_pytest(*, remove: bool = False) -> None:
             _coverage_instructions_pytest()
     else:
         if is_bitbucket_used():
-            remove_bitbucket_pytest_steps()
+            pass
 
         if RuffTool().is_used():
             deselect_ruff_rules(tool.get_associated_ruff_rules())
         tool.remove_pyproject_configs()
         remove_deps_from_group([*tool.dev_deps, Dependency(name="pytest-cov")], "test")
 
-        remove_pytest_dir()  # Last, since this is a manual step
+        remove_pytest_dir()
 
         if CoverageTool().is_used():
             _coverage_instructions_basic()
@@ -270,7 +252,6 @@ def use_requirements_txt(*, remove: bool = False) -> None:
             tool.add_pre_commit_repo_configs()
 
         if not path.exists():
-            # N.B. this is where a task runner would come in handy, to reduce duplication.
             if not (Path.cwd() / "uv.lock").exists():
                 tick_print("Writing 'uv.lock'.")
                 call_uv_subprocess(["lock"])
@@ -344,12 +325,12 @@ def use_ruff(*, remove: bool = False) -> None:
         if PreCommitTool().is_used():
             tool.add_pre_commit_repo_configs()
         elif is_bitbucket_used():
-            add_bitbucket_step_in_default(get_bitbucket_ruff_step())
+            add_bitbucket_step_in_default(tool.get_bitbucket_step())
 
         box_print("Run 'ruff check --fix' to run the Ruff linter with autofixes.")
         box_print("Run 'ruff format' to run the Ruff formatter.")
     else:
         tool.remove_pre_commit_repo_configs()
-        remove_bitbucket_step_from_default(get_bitbucket_ruff_step())
-        tool.remove_pyproject_configs()  # N.B. this will remove the selected Ruff rules
+        remove_bitbucket_step_from_default(tool.get_bitbucket_step())
+        tool.remove_pyproject_configs()
         remove_deps_from_group(tool.dev_deps, "dev")

--- a/src/usethis/_core/tool.py
+++ b/src/usethis/_core/tool.py
@@ -6,8 +6,8 @@ from usethis._ci import (
 )
 from usethis._console import box_print, tick_print
 from usethis._integrations.bitbucket.steps import (
-    add_bitbucket_step_in_default,
-    remove_bitbucket_step_from_default,
+    add_bitbucket_steps_in_default,
+    remove_bitbucket_steps_from_default,
 )
 from usethis._integrations.pre_commit.core import (
     install_pre_commit_hooks,
@@ -81,13 +81,13 @@ def use_deptry(*, remove: bool = False) -> None:
         if PreCommitTool().is_used():
             tool.add_pre_commit_repo_configs()
         elif is_bitbucket_used():
-            add_bitbucket_step_in_default(tool.get_bitbucket_step())
+            add_bitbucket_steps_in_default(tool.get_bitbucket_steps())
 
         box_print("Run 'deptry src' to run deptry.")
     else:
         tool.remove_pre_commit_repo_configs()
         tool.remove_pyproject_configs()
-        remove_bitbucket_step_from_default(tool.get_bitbucket_step())
+        remove_bitbucket_steps_from_default(tool.get_bitbucket_steps())
         remove_deps_from_group(tool.dev_deps, "dev")
 
 
@@ -116,13 +116,13 @@ def use_pre_commit(*, remove: bool = False) -> None:
         install_pre_commit_hooks()
 
         if is_bitbucket_used():
-            add_bitbucket_step_in_default(tool.get_bitbucket_step())
+            add_bitbucket_steps_in_default(tool.get_bitbucket_steps())
             _remove_bitbucket_linter_steps_from_default()
 
         box_print("Run 'pre-commit run --all-files' to run the hooks manually.")
     else:
         if is_bitbucket_used():
-            remove_bitbucket_step_from_default(tool.get_bitbucket_step())
+            remove_bitbucket_steps_from_default(tool.get_bitbucket_steps())
             _add_bitbucket_linter_steps_to_default()
 
         # Need pre-commit to be installed so we can uninstall hooks
@@ -158,15 +158,15 @@ def _add_bitbucket_linter_steps_to_default() -> None:
         tools: list[Tool] = [PyprojectFmtTool(), DeptryTool(), RuffTool()]
         for tool in tools:
             if tool.is_used():
-                add_bitbucket_step_in_default(tool.get_bitbucket_step())
+                add_bitbucket_steps_in_default(tool.get_bitbucket_steps())
 
 
 def _remove_bitbucket_linter_steps_from_default() -> None:
     # This order of removing tools should be synced with the order hard-coded
     # in the function which adds steps.
-    remove_bitbucket_step_from_default(PyprojectFmtTool().get_bitbucket_step())
-    remove_bitbucket_step_from_default(DeptryTool().get_bitbucket_step())
-    remove_bitbucket_step_from_default(RuffTool().get_bitbucket_step())
+    remove_bitbucket_steps_from_default(PyprojectFmtTool().get_bitbucket_steps())
+    remove_bitbucket_steps_from_default(DeptryTool().get_bitbucket_steps())
+    remove_bitbucket_steps_from_default(RuffTool().get_bitbucket_steps())
 
 
 def use_pyproject_fmt(*, remove: bool = False) -> None:
@@ -180,7 +180,7 @@ def use_pyproject_fmt(*, remove: bool = False) -> None:
         if not is_pre_commit:
             add_deps_to_group(tool.dev_deps, "dev")
             if is_bitbucket_used():
-                add_bitbucket_step_in_default(tool.get_bitbucket_step())
+                add_bitbucket_steps_in_default(tool.get_bitbucket_steps())
         else:
             tool.add_pre_commit_repo_configs()
 
@@ -191,7 +191,7 @@ def use_pyproject_fmt(*, remove: bool = False) -> None:
         else:
             _pyproject_fmt_instructions_pre_commit()
     else:
-        remove_bitbucket_step_from_default(tool.get_bitbucket_step())
+        remove_bitbucket_steps_from_default(tool.get_bitbucket_steps())
         tool.remove_pyproject_configs()
         tool.remove_pre_commit_repo_configs()
         remove_deps_from_group(tool.dev_deps, "dev")
@@ -338,12 +338,12 @@ def use_ruff(*, remove: bool = False) -> None:
         if PreCommitTool().is_used():
             tool.add_pre_commit_repo_configs()
         elif is_bitbucket_used():
-            add_bitbucket_step_in_default(tool.get_bitbucket_step())
+            add_bitbucket_steps_in_default(tool.get_bitbucket_steps())
 
         box_print("Run 'ruff check --fix' to run the Ruff linter with autofixes.")
         box_print("Run 'ruff format' to run the Ruff formatter.")
     else:
         tool.remove_pre_commit_repo_configs()
-        remove_bitbucket_step_from_default(tool.get_bitbucket_step())
+        remove_bitbucket_steps_from_default(tool.get_bitbucket_steps())
         tool.remove_pyproject_configs()
         remove_deps_from_group(tool.dev_deps, "dev")

--- a/src/usethis/_core/tool.py
+++ b/src/usethis/_core/tool.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from usethis._ci import (
     is_bitbucket_used,
+    remove_bitbucket_pytest_steps,
     update_bitbucket_pytest_steps,
 )
 from usethis._console import box_print, tick_print
@@ -237,7 +238,7 @@ def use_pytest(*, remove: bool = False) -> None:
             _coverage_instructions_pytest()
     else:
         if is_bitbucket_used():
-            update_bitbucket_pytest_steps()
+            remove_bitbucket_pytest_steps()
 
         if RuffTool().is_used():
             deselect_ruff_rules(tool.get_associated_ruff_rules())

--- a/src/usethis/_core/tool.py
+++ b/src/usethis/_core/tool.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 from usethis._ci import (
     is_bitbucket_used,
+    remove_bitbucket_pytest_steps,
+    update_bitbucket_pytest_steps,
 )
 from usethis._console import box_print, tick_print
 from usethis._integrations.bitbucket.steps import (
@@ -79,13 +81,17 @@ def use_deptry(*, remove: bool = False) -> None:
         if PreCommitTool().is_used():
             tool.add_pre_commit_repo_configs()
         elif is_bitbucket_used():
-            add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
+            step = DeptryTool().get_bitbucket_step()
+            if step:
+                add_bitbucket_step_in_default(step)
 
         box_print("Run 'deptry src' to run deptry.")
     else:
         tool.remove_pre_commit_repo_configs()
         tool.remove_pyproject_configs()
-        remove_bitbucket_step_from_default(DeptryTool().get_bitbucket_step())
+        step = DeptryTool().get_bitbucket_step()
+        if step:
+            remove_bitbucket_step_from_default(step)
         remove_deps_from_group(tool.dev_deps, "dev")
 
 
@@ -100,6 +106,7 @@ def use_pre_commit(*, remove: bool = False) -> None:
         _add_all_tools_pre_commit_configs()
 
         if pyproject_fmt_tool.is_used():
+            # We will use pre-commit instead of the dev-dep.
             remove_deps_from_group(pyproject_fmt_tool.dev_deps, "dev")
             pyproject_fmt_tool.add_pyproject_configs()
             _pyproject_fmt_instructions_pre_commit()
@@ -113,15 +120,20 @@ def use_pre_commit(*, remove: bool = False) -> None:
         install_pre_commit_hooks()
 
         if is_bitbucket_used():
-            add_bitbucket_step_in_default(PreCommitTool().get_bitbucket_step())
+            step = PreCommitTool().get_bitbucket_step()
+            if step:
+                add_bitbucket_step_in_default(step)
             _remove_bitbucket_linter_steps_from_default()
 
         box_print("Run 'pre-commit run --all-files' to run the hooks manually.")
     else:
         if is_bitbucket_used():
-            remove_bitbucket_step_from_default(PreCommitTool().get_bitbucket_step())
+            step = PreCommitTool().get_bitbucket_step()
+            if step:
+                remove_bitbucket_step_from_default(step)
             _add_bitbucket_linter_steps_to_default()
 
+        # Need pre-commit to be installed so we can uninstall hooks
         add_deps_to_group(tool.dev_deps, "dev")
 
         uninstall_pre_commit_hooks()
@@ -129,10 +141,14 @@ def use_pre_commit(*, remove: bool = False) -> None:
         remove_pre_commit_config()
         remove_deps_from_group(tool.dev_deps, "dev")
 
+        # Need to add a new way of running some hooks manually if they are not dev
+        # dependencies yet - explain to the user.
         if pyproject_fmt_tool.is_used():
             add_deps_to_group(pyproject_fmt_tool.dev_deps, "dev")
             _pyproject_fmt_instructions_basic()
 
+        # Likewise, explain how to manually generate the requirements.txt file, since
+        # they're not going to do it via pre-commit anymore.
         if RequirementsTxtTool().is_used():
             _requirements_txt_instructions_basic()
 
@@ -145,18 +161,27 @@ def _add_all_tools_pre_commit_configs():
 
 def _add_bitbucket_linter_steps_to_default() -> None:
     if is_bitbucket_used():
-        if PyprojectFmtTool().is_used():
-            add_bitbucket_step_in_default(PyprojectFmtTool().get_bitbucket_step())
-        if DeptryTool().is_used():
-            add_bitbucket_step_in_default(DeptryTool().get_bitbucket_step())
-        if RuffTool().is_used():
-            add_bitbucket_step_in_default(RuffTool().get_bitbucket_step())
+        step = PyprojectFmtTool().get_bitbucket_step()
+        if step:
+            add_bitbucket_step_in_default(step)
+        step = DeptryTool().get_bitbucket_step()
+        if step:
+            add_bitbucket_step_in_default(step)
+        step = RuffTool().get_bitbucket_step()
+        if step:
+            add_bitbucket_step_in_default(step)
 
 
 def _remove_bitbucket_linter_steps_from_default() -> None:
-    remove_bitbucket_step_from_default(PyprojectFmtTool().get_bitbucket_step())
-    remove_bitbucket_step_from_default(DeptryTool().get_bitbucket_step())
-    remove_bitbucket_step_from_default(RuffTool().get_bitbucket_step())
+    step = PyprojectFmtTool().get_bitbucket_step()
+    if step:
+        remove_bitbucket_step_from_default(step)
+    step = DeptryTool().get_bitbucket_step()
+    if step:
+        remove_bitbucket_step_from_default(step)
+    step = RuffTool().get_bitbucket_step()
+    if step:
+        remove_bitbucket_step_from_default(step)
 
 
 def use_pyproject_fmt(*, remove: bool = False) -> None:
@@ -170,7 +195,9 @@ def use_pyproject_fmt(*, remove: bool = False) -> None:
         if not is_pre_commit:
             add_deps_to_group(tool.dev_deps, "dev")
             if is_bitbucket_used():
-                add_bitbucket_step_in_default(tool.get_bitbucket_step())
+                step = tool.get_bitbucket_step()
+                if step:
+                    add_bitbucket_step_in_default(step)
         else:
             tool.add_pre_commit_repo_configs()
 
@@ -181,7 +208,9 @@ def use_pyproject_fmt(*, remove: bool = False) -> None:
         else:
             _pyproject_fmt_instructions_pre_commit()
     else:
-        remove_bitbucket_step_from_default(tool.get_bitbucket_step())
+        step = tool.get_bitbucket_step()
+        if step:
+            remove_bitbucket_step_from_default(step)
         tool.remove_pyproject_configs()
         tool.remove_pre_commit_repo_configs()
         remove_deps_from_group(tool.dev_deps, "dev")
@@ -210,10 +239,13 @@ def use_pytest(*, remove: bool = False) -> None:
         if RuffTool().is_used():
             select_ruff_rules(tool.get_associated_ruff_rules())
 
+        # deptry currently can't scan the tests folder for dev deps
+        # https://github.com/fpgmaas/deptry/issues/302
+
         add_pytest_dir()
 
         if is_bitbucket_used():
-            pass
+            update_bitbucket_pytest_steps()
 
         box_print(
             "Add test files to the '/tests' directory with the format 'test_*.py'."
@@ -225,14 +257,14 @@ def use_pytest(*, remove: bool = False) -> None:
             _coverage_instructions_pytest()
     else:
         if is_bitbucket_used():
-            pass
+            remove_bitbucket_pytest_steps()
 
         if RuffTool().is_used():
             deselect_ruff_rules(tool.get_associated_ruff_rules())
         tool.remove_pyproject_configs()
         remove_deps_from_group([*tool.dev_deps, Dependency(name="pytest-cov")], "test")
 
-        remove_pytest_dir()
+        remove_pytest_dir()  # Last, since this is a manual step
 
         if CoverageTool().is_used():
             _coverage_instructions_basic()
@@ -252,6 +284,7 @@ def use_requirements_txt(*, remove: bool = False) -> None:
             tool.add_pre_commit_repo_configs()
 
         if not path.exists():
+            # N.B. this is where a task runner would come in handy, to reduce duplication.
             if not (Path.cwd() / "uv.lock").exists():
                 tick_print("Writing 'uv.lock'.")
                 call_uv_subprocess(["lock"])
@@ -325,12 +358,16 @@ def use_ruff(*, remove: bool = False) -> None:
         if PreCommitTool().is_used():
             tool.add_pre_commit_repo_configs()
         elif is_bitbucket_used():
-            add_bitbucket_step_in_default(tool.get_bitbucket_step())
+            step = tool.get_bitbucket_step()
+            if step:
+                add_bitbucket_step_in_default(step)
 
         box_print("Run 'ruff check --fix' to run the Ruff linter with autofixes.")
         box_print("Run 'ruff format' to run the Ruff formatter.")
     else:
         tool.remove_pre_commit_repo_configs()
-        remove_bitbucket_step_from_default(tool.get_bitbucket_step())
+        step = tool.get_bitbucket_step()
+        if step:
+            remove_bitbucket_step_from_default(step)
         tool.remove_pyproject_configs()
         remove_deps_from_group(tool.dev_deps, "dev")

--- a/src/usethis/_integrations/bitbucket/steps.py
+++ b/src/usethis/_integrations/bitbucket/steps.py
@@ -59,6 +59,11 @@ for name, script_item in _SCRIPT_ITEM_LOOKUP.items():
     script_item.yaml_set_anchor(value=name, always_dump=True)
 
 
+def add_bitbucket_steps_in_default(steps: list[Step]) -> None:
+    for step in steps:
+        add_bitbucket_step_in_default(step)
+
+
 def add_bitbucket_step_in_default(step: Step) -> None:
     try:
         existing_steps = get_steps_in_default()
@@ -174,6 +179,11 @@ def _add_step_in_default_via_doc(
         apply_pipeweld_instruction_via_doc(
             instruction=instruction, new_step=step, doc=doc
         )
+
+
+def remove_bitbucket_steps_from_default(steps: list[Step]) -> None:
+    for step in steps:
+        remove_bitbucket_step_from_default(step)
 
 
 def remove_bitbucket_step_from_default(step: Step) -> None:

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -3,8 +3,11 @@ from pathlib import Path
 from typing import Protocol
 
 from usethis._console import tick_print
-from usethis._integrations.bitbucket.anchor import ScriptItemAnchor
-from usethis._integrations.bitbucket.schema import Script, Step
+from usethis._integrations.bitbucket.anchor import (
+    ScriptItemAnchor as BitbucketScriptItemAnchor,
+)
+from usethis._integrations.bitbucket.schema import Script as BitbucketScript
+from usethis._integrations.bitbucket.schema import Step as BitbucketStep
 from usethis._integrations.pre_commit.hooks import (
     add_repo,
     get_hook_names,
@@ -39,12 +42,11 @@ class Tool(Protocol):
         with the tool; if not, make sure to override methods which access this property.
         """
 
-    def get_bitbucket_step(self) -> Step | None:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         """Get the Bitbucket pipeline step for this tool.
 
         Returns:
-            Optional[Step]: A Bitbucket pipeline step configuration for CI/CD, or None if the tool
-            doesn't have a pipeline step.
+           A Bitbucket pipeline step configuration for CI/CD
         """
         return None
 
@@ -262,13 +264,13 @@ class DeptryTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "deptry"]]
       
-    def get_bitbucket_step(self) -> Step:
-        return Step(
+    def get_bitbucket_step(self) -> BitbucketStep:
+        return BitbucketStep(
             name="Run Deptry",
             caches=["uv"],
-            script=Script(
+            script=BitbucketScript(
                 [
-                    ScriptItemAnchor(name="install-uv"),
+                    BitbucketScriptItemAnchor(name="install-uv"),
                     "uv run deptry src",
                 ]
             ),
@@ -287,13 +289,13 @@ class PreCommitTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path(".pre-commit-config.yaml")]
 
-    def get_bitbucket_step(self) -> Step:
-        return Step(
+    def get_bitbucket_step(self) -> BitbucketStep:
+        return BitbucketStep(
             name="Run pre-commit",
             caches=["uv", "pre-commit"],
-            script=Script(
+            script=BitbucketScript(
                 [
-                    ScriptItemAnchor(name="install-uv"),
+                    BitbucketScriptItemAnchor(name="install-uv"),
                     "uv run pre-commit run --all-files",
                 ]
             ),
@@ -329,13 +331,13 @@ class PyprojectFmtTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]
 
-    def get_bitbucket_step(self) -> Step:
-        return Step(
+    def get_bitbucket_step(self) -> BitbucketStep:
+        return BitbucketStep(
             name="Run pyproject-fmt",
             caches=["uv"],
-            script=Script(
+            script=BitbucketScript(
                 [
-                    ScriptItemAnchor(name="install-uv"),
+                    BitbucketScriptItemAnchor(name="install-uv"),
                     "uv run pyproject-fmt pyproject.toml",
                 ]
             ),
@@ -474,13 +476,13 @@ class RuffTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path("ruff.toml"), Path(".ruff.toml")]
 
-    def get_bitbucket_step(self) -> Step:
-        return Step(
+    def get_bitbucket_step(self) -> BitbucketStep:
+        return BitbucketStep(
             name="Run Ruff",
             caches=["uv"],
-            script=Script(
+            script=BitbucketScript(
                 [
-                    ScriptItemAnchor(name="install-uv"),
+                    BitbucketScriptItemAnchor(name="install-uv"),
                     "uv run ruff check --fix",
                     "uv run ruff format",
                 ]

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -263,7 +263,7 @@ class DeptryTool(Tool):
 
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "deptry"]]
-      
+
     def get_bitbucket_step(self) -> BitbucketStep:
         return BitbucketStep(
             name="Run Deptry",

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -263,8 +263,8 @@ class DeptryTool(Tool):
 
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "deptry"]]
-      
-    def get_bitbucket_step(self) -> BitbucketStep:
+
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run Deptry",
             caches=["uv"],
@@ -289,7 +289,7 @@ class PreCommitTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path(".pre-commit-config.yaml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run pre-commit",
             caches=["uv", "pre-commit"],
@@ -331,7 +331,7 @@ class PyprojectFmtTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]
 
-    def get_bitbucket_step(self) -> BitbucketStep:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run pyproject-fmt",
             caches=["uv"],
@@ -476,7 +476,7 @@ class RuffTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path("ruff.toml"), Path(".ruff.toml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run Ruff",
             caches=["uv"],

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -36,6 +36,10 @@ class Tool(Protocol):
         It is assumed that this name is also the name of the Python package associated
         with the tool; if not, make sure to override methods which access this property.
         """
+        
+    @abstractmethod
+    def get_bitbucket_step(self) -> str:
+        """Get the Bitbucket pipeline step for this tool."""
 
     @property
     def dev_deps(self) -> list[Dependency]:

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -2,6 +2,8 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Protocol
 
+from usethis._integrations.bitbucket.schema import Step
+
 from usethis._console import tick_print
 from usethis._integrations.pre_commit.hooks import (
     add_repo,
@@ -38,8 +40,12 @@ class Tool(Protocol):
         """
         
     @abstractmethod
-    def get_bitbucket_step(self) -> str:
-        """Get the Bitbucket pipeline step for this tool."""
+    def get_bitbucket_step(self) -> Step:
+        """Get the Bitbucket pipeline step for this tool.
+        
+        Returns:
+            Step: A Bitbucket pipeline step configuration for CI/CD.
+        """
 
     @property
     def dev_deps(self) -> list[Dependency]:
@@ -281,6 +287,18 @@ class PyprojectFmtTool(Tool):
                 value={"keep_full_version": True},
             )
         ]
+    
+    def get_bitbucket_step(self) -> Step:
+        return Step(
+            name="Run pre-commit",
+            caches=["uv", "pre-commit"],
+            script=Script(
+                [
+                    ScriptItemAnchor(name="install-uv"),
+                    "uv run pre-commit run --all-files",
+                ]
+            ),
+        )
 
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -264,7 +264,7 @@ class DeptryTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "deptry"]]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
+    def get_bitbucket_step(self) -> BitbucketStep:
         return BitbucketStep(
             name="Run Deptry",
             caches=["uv"],
@@ -289,7 +289,7 @@ class PreCommitTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path(".pre-commit-config.yaml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
+    def get_bitbucket_step(self) -> BitbucketStep:
         return BitbucketStep(
             name="Run pre-commit",
             caches=["uv", "pre-commit"],
@@ -331,7 +331,7 @@ class PyprojectFmtTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
+    def get_bitbucket_step(self) -> BitbucketStep:
         return BitbucketStep(
             name="Run pyproject-fmt",
             caches=["uv"],
@@ -476,7 +476,7 @@ class RuffTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path("ruff.toml"), Path(".ruff.toml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
+    def get_bitbucket_step(self) -> BitbucketStep:
         return BitbucketStep(
             name="Run Ruff",
             caches=["uv"],

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -2,7 +2,8 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Protocol
 
-from usethis._integrations.bitbucket.schema import Step
+from usethis._integrations.bitbucket.schema import Step,Script
+from usethis._integrations.bitbucket.anchor import ScriptItemAnchor
 
 from usethis._console import tick_print
 from usethis._integrations.pre_commit.hooks import (
@@ -247,6 +248,18 @@ class DeptryTool(Tool):
                 ],
             )
         ]
+    
+    def get_bitbucket_step(self) -> Step:
+        return Step(
+            name="Run Deptry",
+            caches=["uv"],
+            script=Script(
+                [
+                    ScriptItemAnchor(name="install-uv"),
+                    "uv run deptry src",
+                ]
+            ),
+        )
 
 
 class PreCommitTool(Tool):
@@ -260,6 +273,18 @@ class PreCommitTool(Tool):
 
     def get_managed_files(self) -> list[Path]:
         return [Path(".pre-commit-config.yaml")]
+    
+    def get_bitbucket_step(self) -> Step:
+        return Step(
+            name="Run pre-commit",
+            caches=["uv", "pre-commit"],
+            script=Script(
+                [
+                    ScriptItemAnchor(name="install-uv"),
+                    "uv run pre-commit run --all-files",
+                ]
+            ),
+        )
 
 
 class PyprojectFmtTool(Tool):
@@ -287,21 +312,21 @@ class PyprojectFmtTool(Tool):
                 value={"keep_full_version": True},
             )
         ]
-    
-    def get_bitbucket_step(self) -> Step:
-        return Step(
-            name="Run pre-commit",
-            caches=["uv", "pre-commit"],
-            script=Script(
-                [
-                    ScriptItemAnchor(name="install-uv"),
-                    "uv run pre-commit run --all-files",
-                ]
-            ),
-        )
 
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]
+    
+    def get_bitbucket_step(self) -> Step:
+        return Step(
+            name="Run pyproject-fmt",
+            caches=["uv"],
+            script=Script(
+                [
+                    ScriptItemAnchor(name="install-uv"),
+                    "uv run pyproject-fmt pyproject.toml",
+                ]
+            ),
+        )
 
 
 class PytestTool(Tool):
@@ -435,6 +460,19 @@ class RuffTool(Tool):
 
     def get_managed_files(self) -> list[Path]:
         return [Path("ruff.toml"), Path(".ruff.toml")]
+    
+    def get_bitbucket_step(self) -> Step:
+        return Step(
+            name="Run Ruff",
+            caches=["uv"],
+            script=Script(
+                [
+                    ScriptItemAnchor(name="install-uv"),
+                    "uv run ruff check --fix",
+                    "uv run ruff format",
+                ]
+            ),
+        )
 
 
 ALL_TOOLS: list[Tool] = [

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -263,7 +263,7 @@ class DeptryTool(Tool):
 
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "deptry"]]
-
+      
     def get_bitbucket_step(self) -> BitbucketStep:
         return BitbucketStep(
             name="Run Deptry",

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -264,7 +264,7 @@ class DeptryTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "deptry"]]
 
-    def get_bitbucket_step(self) -> BitbucketStep:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run Deptry",
             caches=["uv"],
@@ -289,7 +289,7 @@ class PreCommitTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path(".pre-commit-config.yaml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run pre-commit",
             caches=["uv", "pre-commit"],
@@ -331,7 +331,7 @@ class PyprojectFmtTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]
 
-    def get_bitbucket_step(self) -> BitbucketStep:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run pyproject-fmt",
             caches=["uv"],
@@ -476,7 +476,7 @@ class RuffTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path("ruff.toml"), Path(".ruff.toml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep:
+    def get_bitbucket_step(self) -> BitbucketStep | None:
         return BitbucketStep(
             name="Run Ruff",
             caches=["uv"],

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -42,13 +42,9 @@ class Tool(Protocol):
         with the tool; if not, make sure to override methods which access this property.
         """
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
-        """Get the Bitbucket pipeline step for this tool.
-
-        Returns:
-           A Bitbucket pipeline step configuration for CI/CD
-        """
-        return None
+    def get_bitbucket_steps(self) -> list[BitbucketStep]:
+        """Get the Bitbucket pipeline step associated with this tool."""
+        return []
 
     @property
     def dev_deps(self) -> list[Dependency]:
@@ -264,17 +260,19 @@ class DeptryTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "deptry"]]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
-        return BitbucketStep(
-            name="Run Deptry",
-            caches=["uv"],
-            script=BitbucketScript(
-                [
-                    BitbucketScriptItemAnchor(name="install-uv"),
-                    "uv run deptry src",
-                ]
-            ),
-        )
+    def get_bitbucket_steps(self) -> list[BitbucketStep]:
+        return [
+            BitbucketStep(
+                name="Run Deptry",
+                caches=["uv"],
+                script=BitbucketScript(
+                    [
+                        BitbucketScriptItemAnchor(name="install-uv"),
+                        "uv run deptry src",
+                    ]
+                ),
+            )
+        ]
 
 
 class PreCommitTool(Tool):
@@ -289,17 +287,19 @@ class PreCommitTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path(".pre-commit-config.yaml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
-        return BitbucketStep(
-            name="Run pre-commit",
-            caches=["uv", "pre-commit"],
-            script=BitbucketScript(
-                [
-                    BitbucketScriptItemAnchor(name="install-uv"),
-                    "uv run pre-commit run --all-files",
-                ]
-            ),
-        )
+    def get_bitbucket_steps(self) -> list[BitbucketStep]:
+        return [
+            BitbucketStep(
+                name="Run pre-commit",
+                caches=["uv", "pre-commit"],
+                script=BitbucketScript(
+                    [
+                        BitbucketScriptItemAnchor(name="install-uv"),
+                        "uv run pre-commit run --all-files",
+                    ]
+                ),
+            )
+        ]
 
 
 class PyprojectFmtTool(Tool):
@@ -331,17 +331,19 @@ class PyprojectFmtTool(Tool):
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
-        return BitbucketStep(
-            name="Run pyproject-fmt",
-            caches=["uv"],
-            script=BitbucketScript(
-                [
-                    BitbucketScriptItemAnchor(name="install-uv"),
-                    "uv run pyproject-fmt pyproject.toml",
-                ]
-            ),
-        )
+    def get_bitbucket_steps(self) -> list[BitbucketStep]:
+        return [
+            BitbucketStep(
+                name="Run pyproject-fmt",
+                caches=["uv"],
+                script=BitbucketScript(
+                    [
+                        BitbucketScriptItemAnchor(name="install-uv"),
+                        "uv run pyproject-fmt pyproject.toml",
+                    ]
+                ),
+            )
+        ]
 
 
 class PytestTool(Tool):
@@ -476,18 +478,20 @@ class RuffTool(Tool):
     def get_managed_files(self) -> list[Path]:
         return [Path("ruff.toml"), Path(".ruff.toml")]
 
-    def get_bitbucket_step(self) -> BitbucketStep | None:
-        return BitbucketStep(
-            name="Run Ruff",
-            caches=["uv"],
-            script=BitbucketScript(
-                [
-                    BitbucketScriptItemAnchor(name="install-uv"),
-                    "uv run ruff check --fix",
-                    "uv run ruff format",
-                ]
-            ),
-        )
+    def get_bitbucket_steps(self) -> list[BitbucketStep]:
+        return [
+            BitbucketStep(
+                name="Run Ruff",
+                caches=["uv"],
+                script=BitbucketScript(
+                    [
+                        BitbucketScriptItemAnchor(name="install-uv"),
+                        "uv run ruff check --fix",
+                        "uv run ruff format",
+                    ]
+                ),
+            )
+        ]
 
 
 ALL_TOOLS: list[Tool] = [

--- a/src/usethis/_tool.py
+++ b/src/usethis/_tool.py
@@ -2,10 +2,9 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Protocol
 
-from usethis._integrations.bitbucket.schema import Step,Script
-from usethis._integrations.bitbucket.anchor import ScriptItemAnchor
-
 from usethis._console import tick_print
+from usethis._integrations.bitbucket.anchor import ScriptItemAnchor
+from usethis._integrations.bitbucket.schema import Script, Step
 from usethis._integrations.pre_commit.hooks import (
     add_repo,
     get_hook_names,
@@ -39,14 +38,15 @@ class Tool(Protocol):
         It is assumed that this name is also the name of the Python package associated
         with the tool; if not, make sure to override methods which access this property.
         """
-        
-    @abstractmethod
-    def get_bitbucket_step(self) -> Step:
+
+    def get_bitbucket_step(self) -> Step | None:
         """Get the Bitbucket pipeline step for this tool.
-        
+
         Returns:
-            Step: A Bitbucket pipeline step configuration for CI/CD.
+            Optional[Step]: A Bitbucket pipeline step configuration for CI/CD, or None if the tool
+            doesn't have a pipeline step.
         """
+        return None
 
     @property
     def dev_deps(self) -> list[Dependency]:
@@ -248,7 +248,7 @@ class DeptryTool(Tool):
                 ],
             )
         ]
-    
+
     def get_bitbucket_step(self) -> Step:
         return Step(
             name="Run Deptry",
@@ -273,7 +273,7 @@ class PreCommitTool(Tool):
 
     def get_managed_files(self) -> list[Path]:
         return [Path(".pre-commit-config.yaml")]
-    
+
     def get_bitbucket_step(self) -> Step:
         return Step(
             name="Run pre-commit",
@@ -315,7 +315,7 @@ class PyprojectFmtTool(Tool):
 
     def get_pyproject_id_keys(self) -> list[list[str]]:
         return [["tool", "pyproject-fmt"]]
-    
+
     def get_bitbucket_step(self) -> Step:
         return Step(
             name="Run pyproject-fmt",
@@ -460,7 +460,7 @@ class RuffTool(Tool):
 
     def get_managed_files(self) -> list[Path]:
         return [Path("ruff.toml"), Path(".ruff.toml")]
-    
+
     def get_bitbucket_step(self) -> Step:
         return Step(
             name="Run Ruff",

--- a/tests/usethis/_core/test_tool.py
+++ b/tests/usethis/_core/test_tool.py
@@ -1151,15 +1151,6 @@ pipelines:
                     use_pytest(remove=True)
 
                 # Assert
-                out, err = capfd.readouterr()
-                assert not err
-                assert out.replace("\n", "").replace(" ", "") == (
-                    "✔ Removing 'Test on 3.12' from default pipeline in 'bitbucket-pipelines.yml'.\n"
-                    "✔ Adding cache 'uv' definition to 'bitbucket-pipelines.yml'.\n"
-                    "✔ Removing pytest config from 'pyproject.toml'.\n"
-                    "✔ Removing dependency 'pytest' from the 'test' group in 'pyproject.toml'.\n"
-                    "✔ Removing '/tests'.\n"
-                ).replace("\n", "").replace(" ", "")
                 contents = (uv_init_dir / "bitbucket-pipelines.yml").read_text()
                 assert (
                     contents
@@ -1185,6 +1176,15 @@ pipelines:
               - echo 'Hello, world!'
 """
                 )
+                out, err = capfd.readouterr()
+                assert not err
+                assert out.replace("\n", "").replace(" ", "") == (
+                    "✔ Removing 'Test on 3.12' from default pipeline in 'bitbucket-pipelines.yml'.\n"
+                    "✔ Adding cache 'uv' definition to 'bitbucket-pipelines.yml'.\n"
+                    "✔ Removing pytest config from 'pyproject.toml'.\n"
+                    "✔ Removing dependency 'pytest' from the 'test' group in 'pyproject.toml'.\n"
+                    "✔ Removing '/tests'.\n"
+                ).replace("\n", "").replace(" ", "")
 
         def test_coverage_integration(
             self, uv_init_dir: Path, capfd: pytest.CaptureFixture[str]

--- a/uv.lock
+++ b/uv.lock
@@ -1313,8 +1313,8 @@ requires-dist = [
     { name = "requests", specifier = ">=2.26.0" },
     { name = "rich", specifier = ">=9.6.1" },
     { name = "ruamel-yaml", specifier = ">=0.16.13" },
-    { name = "tomlkit", specifier = ">=0.7.1" },
-    { name = "typer", specifier = ">=0.4.0" },
+    { name = "tomlkit", specifier = ">=0.12.0" },
+    { name = "typer", specifier = ">=0.4.1" },
     { name = "typing-extensions", specifier = ">=3.10.0.0" },
 ]
 


### PR DESCRIPTION
Moved each Bitbucket pipeline step into its respective Tool class by:
1. Adding a new abstract `get_bitbucket_step()` method to the Tool protocol
2. Implementing this method in relevant tool classes:
   - PreCommitTool
   - RuffTool
   - DeptryTool
   - PyprojectFmtTool