### PR TITLE
Add a --show flag for usethis badge

### DIFF
--- a/src/usethis/_interface/badge.py
+++ b/src/usethis/_interface/badge.py
@@ -23,9 +23,8 @@ remove_opt = typer.Option(
     False, "--remove", help="Remove the badge instead of adding it."
 )
 
-show_opt = typer.Option(
-    False, "--show", help="Print the badge to the console."
-)
+show_opt = typer.Option(False, "--show", help="Print the badge to the console.")
+
 
 @app.command(help="Add a badge with the version of your package on PyPI.")
 def pypi(
@@ -35,7 +34,7 @@ def pypi(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_pypi_badge(), remove=remove, show=show)
+        _badge_effect(get_pypi_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for the Ruff linter.")
@@ -46,7 +45,7 @@ def ruff(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_ruff_badge(), remove=remove, show=show)
+        _badge_effect(get_ruff_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for the pre-commit framework.")
@@ -57,7 +56,7 @@ def pre_commit(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_pre_commit_badge(), remove=remove, show=show)
+        _badge_effect(get_pre_commit_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for usethis.")
@@ -68,7 +67,7 @@ def usethis(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_usethis_badge(), remove=remove, show=show)
+        _badge_effect(get_usethis_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for the uv package manager.")
@@ -79,21 +78,21 @@ def uv(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_uv_badge(), remove=remove, show=show)
+        _badge_effect(get_uv_badge(), remove=remove, show=show)
 
 
-def _modify_badge(
+def _badge_effect(
     badge: Badge,
     remove: bool = False,
     show: bool = False,
 ):
     try:
-        if not remove:
+        if show:
+            print(badge.markdown)
+        elif not remove:
             add_badge(badge)
         else:
             remove_badge(badge)
-        if show:
-            print(badge.markdown)
     except UsethisError as err:
         err_print(err)
         raise typer.Exit(code=1) from None

--- a/src/usethis/_interface/badge.py
+++ b/src/usethis/_interface/badge.py
@@ -24,7 +24,7 @@ remove_opt = typer.Option(
 )
 
 show_opt = typer.Option(
-    False, "--show", help="Print the badge to the console instead of adding it."
+    False, "--show", help="Print the badge to the console."
 )
 
 @app.command(help="Add a badge with the version of your package on PyPI.")
@@ -35,10 +35,7 @@ def pypi(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        if show:
-            print(get_pypi_badge().markdown)
-        else:
-            _modify_badge(get_pypi_badge(), remove=remove)
+        _modify_badge(get_pypi_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for the Ruff linter.")
@@ -49,10 +46,7 @@ def ruff(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        if show:
-            print(get_ruff_badge().markdown)
-        else:
-            _modify_badge(get_ruff_badge(), remove=remove)
+        _modify_badge(get_ruff_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for the pre-commit framework.")
@@ -63,10 +57,7 @@ def pre_commit(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        if show:
-            print(get_pre_commit_badge().markdown)
-        else:
-            _modify_badge(get_pre_commit_badge(), remove=remove)
+        _modify_badge(get_pre_commit_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for usethis.")
@@ -77,10 +68,7 @@ def usethis(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        if show:
-            print(get_usethis_badge().markdown)
-        else:
-            _modify_badge(get_usethis_badge(), remove=remove)
+        _modify_badge(get_usethis_badge(), remove=remove, show=show)
 
 
 @app.command(help="Add a badge for the uv package manager.")
@@ -91,21 +79,21 @@ def uv(
     show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        if show:
-            print(get_uv_badge().markdown)
-        else:
-            _modify_badge(get_uv_badge(), remove=remove)
+        _modify_badge(get_uv_badge(), remove=remove, show=show)
 
 
 def _modify_badge(
     badge: Badge,
     remove: bool = False,
+    show: bool = False,
 ):
     try:
         if not remove:
             add_badge(badge)
         else:
             remove_badge(badge)
+        if show:
+            print(badge.markdown)
     except UsethisError as err:
         err_print(err)
         raise typer.Exit(code=1) from None

--- a/src/usethis/_interface/badge.py
+++ b/src/usethis/_interface/badge.py
@@ -23,15 +23,22 @@ remove_opt = typer.Option(
     False, "--remove", help="Remove the badge instead of adding it."
 )
 
+show_opt = typer.Option(
+    False, "--show", help="Print the badge to the console instead of adding it."
+)
 
 @app.command(help="Add a badge with the version of your package on PyPI.")
 def pypi(
     remove: bool = remove_opt,
     offline: bool = offline_opt,
     quiet: bool = quiet_opt,
+    show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_pypi_badge(), remove=remove)
+        if show:
+            print(get_pypi_badge().markdown)
+        else:
+            _modify_badge(get_pypi_badge(), remove=remove)
 
 
 @app.command(help="Add a badge for the Ruff linter.")
@@ -39,9 +46,13 @@ def ruff(
     remove: bool = remove_opt,
     offline: bool = offline_opt,
     quiet: bool = quiet_opt,
+    show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_ruff_badge(), remove=remove)
+        if show:
+            print(get_ruff_badge().markdown)
+        else:
+            _modify_badge(get_ruff_badge(), remove=remove)
 
 
 @app.command(help="Add a badge for the pre-commit framework.")
@@ -49,9 +60,13 @@ def pre_commit(
     remove: bool = remove_opt,
     offline: bool = offline_opt,
     quiet: bool = quiet_opt,
+    show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_pre_commit_badge(), remove=remove)
+        if show:
+            print(get_pre_commit_badge().markdown)
+        else:
+            _modify_badge(get_pre_commit_badge(), remove=remove)
 
 
 @app.command(help="Add a badge for usethis.")
@@ -59,9 +74,13 @@ def usethis(
     remove: bool = remove_opt,
     offline: bool = offline_opt,
     quiet: bool = quiet_opt,
+    show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_usethis_badge(), remove=remove)
+        if show:
+            print(get_usethis_badge().markdown)
+        else:
+            _modify_badge(get_usethis_badge(), remove=remove)
 
 
 @app.command(help="Add a badge for the uv package manager.")
@@ -69,9 +88,13 @@ def uv(
     remove: bool = remove_opt,
     offline: bool = offline_opt,
     quiet: bool = quiet_opt,
+    show: bool = show_opt,
 ) -> None:
     with usethis_config.set(offline=offline, quiet=quiet), files_manager():
-        _modify_badge(get_uv_badge(), remove=remove)
+        if show:
+            print(get_uv_badge().markdown)
+        else:
+            _modify_badge(get_uv_badge(), remove=remove)
 
 
 def _modify_badge(

--- a/tests/usethis/_interface/test_interface_badge.py
+++ b/tests/usethis/_interface/test_interface_badge.py
@@ -28,6 +28,18 @@ class TestPyPI:
         # Assert
         assert result.exit_code == 0, result.output
 
+    def test_show(self, tmp_path: Path):
+        # Arrange
+        (tmp_path / "README.md").write_text("")
+
+        # Act
+        runner = CliRunner()
+        with change_cwd(tmp_path):
+            result = runner.invoke(app, ["pypi", "--show"])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+
 
 class TestRuff:
     def test_add(self, tmp_path: Path):
@@ -63,6 +75,18 @@ class TestRuff:
         # Assert
         assert result.exit_code == 0, result.output
 
+    def test_show(self, tmp_path: Path):
+        # Arrange
+        (tmp_path / "README.md").write_text("")
+
+        # Act
+        runner = CliRunner()
+        with change_cwd(tmp_path):
+            result = runner.invoke(app, ["ruff", "--show"])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+
 
 class TestPreCommit:
     def test_add(self, tmp_path: Path):
@@ -82,6 +106,18 @@ class TestPreCommit:
         runner = CliRunner()
         with change_cwd(tmp_path):
             result = runner.invoke(app, ["pre-commit", "--remove"])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+
+    def test_show(self, tmp_path: Path):
+        # Arrange
+        (tmp_path / "README.md").write_text("")
+
+        # Act
+        runner = CliRunner()
+        with change_cwd(tmp_path):
+            result = runner.invoke(app, ["pre-commit", "--show"])
 
         # Assert
         assert result.exit_code == 0, result.output
@@ -109,6 +145,18 @@ class TestUsethis:
         # Assert
         assert result.exit_code == 0, result.output
 
+    def test_show(self, tmp_path: Path):
+        # Arrange
+        (tmp_path / "README.md").write_text("")
+
+        # Act
+        runner = CliRunner()
+        with change_cwd(tmp_path):
+            result = runner.invoke(app, ["usethis", "--show"])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+
 
 class TestUV:
     def test_add(self, tmp_path: Path):
@@ -128,6 +176,18 @@ class TestUV:
         runner = CliRunner()
         with change_cwd(tmp_path):
             result = runner.invoke(app, ["uv", "--remove"])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+
+    def test_show(self, tmp_path: Path):
+        # Arrange
+        (tmp_path / "README.md").write_text("")
+
+        # Act
+        runner = CliRunner()
+        with change_cwd(tmp_path):
+            result = runner.invoke(app, ["uv", "--show"])
 
         # Assert
         assert result.exit_code == 0, result.output

--- a/tests/usethis/_interface/test_interface_badge.py
+++ b/tests/usethis/_interface/test_interface_badge.py
@@ -156,6 +156,10 @@ class TestUsethis:
 
         # Assert
         assert result.exit_code == 0, result.output
+        assert (
+            result.output
+            == "[![usethis](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nathanjmcdougall/usethis-python/main/assets/badge/v1.json)](https://github.com/nathanjmcdougall/usethis-python)\n"
+        )
 
 
 class TestUV:


### PR DESCRIPTION
Implementation of https://github.com/nathanjmcdougall/usethis-python/issues/424.

Use cases:
1. only use `--show` flag:
```
usethis badge pypi --show 
```
![image](https://github.com/user-attachments/assets/7f645ee8-4c04-4688-81c3-41ae7898873d)

It will print the badge to the console and add the badge.

2. use `--show` and `--quiet` at the same time:
It will still print the badge to the console.

3. use `--show` and `--remove` at the same time:
It will print the badge to the console and remove the badge.

If anything doesn’t meet expectations, please let me know and I’ll make the changes.
