### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: CI
+permissions:
+  contents: read
+  secrets: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nathanjmcdougall/usethis-python/security/code-scanning/1](https://github.com/nathanjmcdougall/usethis-python/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `secrets: read` for accessing secrets like `CODSPEED_TOKEN` and `CODECOV_TOKEN`.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
