### PR TITLE
Add a heuristic to determine whether the Ruff linter is being used.

### DIFF
--- a/src/usethis/_tool/impl/ruff.py
+++ b/src/usethis/_tool/impl/ruff.py
@@ -345,3 +345,28 @@ class RuffTool(Tool):
                 f"'{file_manager.name}' of type {file_manager.__class__.__name__}."
             )
             raise NotImplementedError(msg)
+
+    def is_linter_used(self) -> bool:
+        """Check if the linter is used in the project."""
+        return self._is_config_spec_present(
+            ConfigSpec.from_flat(
+                file_managers=[
+                    DotRuffTOMLManager(),
+                    RuffTOMLManager(),
+                    PyprojectTOMLManager(),
+                ],
+                resolution="first",
+                config_items=[
+                    ConfigItem(
+                        description="Linter Config",
+                        root={
+                            Path(".ruff.toml"): ConfigEntry(keys=["lint"]),
+                            Path("ruff.toml"): ConfigEntry(keys=["lint"]),
+                            Path("pyproject.toml"): ConfigEntry(
+                                keys=["tool", "ruff", "lint"]
+                            ),
+                        },
+                    ),
+                ],
+            )
+        )

--- a/tests/usethis/_tool/impl/test_ruff.py
+++ b/tests/usethis/_tool/impl/test_ruff.py
@@ -225,3 +225,35 @@ ignore = ["A"]
 
                 # Assert
                 assert RuffTool().get_ignored_rules() == ["A"]
+
+    class TestIsLinterUsed:
+        def test_no_pyproject_toml(self, tmp_path: Path):
+            # Act
+            with change_cwd(tmp_path), files_manager():
+                assert not RuffTool().is_linter_used()
+
+        def test_pyproject_toml(self, tmp_path: Path):
+            # Arrange
+            (tmp_path / "pyproject.toml").write_text(
+                """\
+[tool.ruff.lint]
+select = ["A"]
+"""
+            )
+
+            # Act
+            with change_cwd(tmp_path), PyprojectTOMLManager():
+                assert RuffTool().is_linter_used()
+
+        def test_ruff_toml(self, tmp_path: Path):
+            # Arrange
+            (tmp_path / ".ruff.toml").write_text(
+                """\
+[lint]
+select = ["A"]
+"""
+            )
+
+            # Act
+            with change_cwd(tmp_path), DotRuffTOMLManager():
+                assert RuffTool().is_linter_used()


### PR DESCRIPTION
This is provided as a new method on the RuffTool class called `is_linter_used`.

The heuristic relies on the presence of a `lint` section in the Ruff configuration.

Some refactoring was required to achieve this, including splitting `is_config_present` in the Tool class into a new helper method `_is_config_spec_present`

Also there seemed to have been a bug where the `is_config_present` method would try and access files that don't exist instead of skipping them for IO